### PR TITLE
Error in the Python Code Snippet

### DIFF
--- a/articles/azure-app-configuration/rest-api-authentication-hmac.md
+++ b/articles/azure-app-configuration/rest-api-authentication-hmac.md
@@ -428,7 +428,7 @@ def sign_request(host,
                 secret):    # Access Key Value
     verb = method.upper()
 
-    utc_now = str(datetime.utcnow().strftime("%b, %d %Y %H:%M:%S ")) + "GMT"
+    utc_now = str(datetime.utcnow().strftime("%a, %d %b %Y %H:%M:%S ")) + "GMT"
 
     if six.PY2:
         content_digest = hashlib.sha256(bytes(body)).digest()


### PR DESCRIPTION
In the Python code snippet, the variable utc_now for Setting the Date header to our Date as a UTC String should be (line 431):

utc_now = str(datetime.utcnow().strftime("%a, %d %b %Y %H:%M:%S ")) + "GMT"

The day of the week %a is needed for the code to match the HMAC header format. The format should be Day of the week, Date Month Year CurrentTime. Example: Tue, 15 Mar 2022 00:27:47 GMT. Without this exact format, the Python REST API code does not work.
This matches up with the documentation for Tutorial: Sign and make requests with Postman - https://docs.microsoft.com/en-us/azure/communication-services/tutorials/postman-tutorial.